### PR TITLE
Fix highlighting of bad spaces.

### DIFF
--- a/plugin/matchindent.vim
+++ b/plugin/matchindent.vim
@@ -119,7 +119,7 @@ function! MatchIndent()
 		match MatchIndentBadIndent /^\t\+/
 	endif
 	if warn_spaces > 0
-		match MatchIndentBadIndent /^\(  \)+/
+		match MatchIndentBadIndent /^\(  \)\+/
 	endif
 	if warn_2_spaces > 0
 		match MatchIndentBadIndent /^  [^ ]/


### PR DESCRIPTION
The \+ in the regex was missing its escape.